### PR TITLE
Fix 0 new cases bug

### DIFF
--- a/__tests__/format-message.test.js
+++ b/__tests__/format-message.test.js
@@ -350,7 +350,7 @@ https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-report
 _Wednesday, 20 May 2020 10:20:18 UTC_
 1845 confirmed cases (96▲)
 18 deaths (5▲)
-💡_Reply *LATEST* for detailed case report_`;
+💡 _Reply *LATEST* for detailed case report_`;
         expect(formatHomepageMessages(mockStatistic, news_data)[0]).toEqual(formattedExample);
   });
   it("should format the news summary message with 1 covid news items", () => {
@@ -383,7 +383,7 @@ _09 Jun 2020 14:53:34 UTC_
 *article 1*
 [some_link]
 
-💡_Reply *NEWS* to read more_`;
+💡 _Reply *NEWS* to read more_`;
         expect(formatHomepageMessages(mockStatistic, news_data)[1]).toEqual(formattedExample);
   });
 });

--- a/__tests__/retrieve-data.test.js
+++ b/__tests__/retrieve-data.test.js
@@ -1,33 +1,52 @@
 const axios = require("axios");
 const {
+  retrieveCountryData,
   retrieveCountryStatsFromArcGis,
+  retrieveGlobalStatsFromArcGis,
   shouldNotHaveToUpdate,
+  lessThanADayOld,
   retrieveContactLanguage
 } = require("../retrieve-data");
+const { Statistics } = require("../models");
 
+// Mock api calls
+jest.mock("axios");
 const mockAxios = jest.genMockFromModule('axios')
 mockAxios.create = jest.fn(() => mockAxios)
 
-mockAxios.mockImplementation(() =>
-  Promise.resolve(() => ({
-    features: [{ attributes: {} }]
-  }))
-);
-
-describe("retrieve data from cache or server", () => {
-  it("should try to fetch data from arcGIS", async done => {
+describe("fetch data from arcGIS APIs", () => {
+  it("should add the country to the country query", async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.indexOf("NLD") >= 0 ) {
+        return Promise.resolve({ "data": {"message": "NLD present in url"}});
+      } else {
+        return Promise.resolve({ "data": {"message": "NLD not present in url"}});
+      }});
     const data = await retrieveCountryStatsFromArcGis("NLD");
-    done();
-  });
-});
-
-describe("retrieve data from cache or server", () => {
-  it("should try to fetch data from arcGIS", async done => {
-    const data = await retrieveCountryStatsFromArcGis("NLD");
-    done();
+    expect(data.message).toBe("NLD present in url");
   });
 
-  it("should not update if less than 8 hours ago", () => {
+  it("should add the date to the global query", async () => {
+    // Mocks
+    const mock_date = new Date('May 20, 2020 11:20:18')
+    const spy = jest
+      .spyOn(global, 'Date')
+      .mockImplementation(() => mock_date)
+
+    axios.get.mockImplementation((url) => {
+      if (url.indexOf("5/20/2020") >= 0 ) {
+        return Promise.resolve({ "data": {"message": "Date present in url"}});
+      } else {
+        return Promise.resolve({ "data": {"message": "Date not present in url"}});
+      }});
+
+    const data = await retrieveGlobalStatsFromArcGis();
+
+    expect(data.message).toBe("Date present in url");
+    spy.mockRestore()
+  });
+
+  it("should not have to update if less than 1 hour old", () => {
     const date = new Date();
     const mock = {
       id: 1,
@@ -40,14 +59,14 @@ describe("retrieve data from cache or server", () => {
       createdAt: date,
       updatedAt: date
     };
-    const oldDate = new Date(new Date() - 30000000);
+    const oldDate = new Date(new Date() - 10000000);
     const oldMock = { ...mock, updatedAt: oldDate };
     expect(shouldNotHaveToUpdate(mock)).toBe(true);
     expect(shouldNotHaveToUpdate(oldMock)).toBe(false);
   });
 
-  it("should get data from the database", () => {
-    const date = new Date();
+  it("should only return true if the cache is less than a day old", () => {
+    const date = new Date(new Date() - (80000000));
     const mock = {
       id: 1,
       country_code: "ZAF",
@@ -59,6 +78,90 @@ describe("retrieve data from cache or server", () => {
       createdAt: date,
       updatedAt: date
     };
+    const oldDate = new Date(new Date() - (90000000));
+    const oldMock = { ...mock, updatedAt: oldDate };
+    expect(lessThanADayOld(mock)).toBe(true);
+    expect(lessThanADayOld(oldMock)).toBe(false);
+  });
+
+  it("should get cached data from the database", async () => {
+    const date = new Date();
+    const stats = await Statistics.create({
+      country_code: "ZAF",
+      updated: date,
+      new_cases: 96,
+      cum_cases: 1845,
+      new_deaths: 5,
+      cum_deaths: 18,
+      createdAt: date,
+      updatedAt: date
+    });
+
+    data = await retrieveCountryData("ZAF");
+    expect(data.cum_cases).toBe(stats.cum_cases)
+  });
+
+  it("should pull data from arcGIS if the cache is empty", async () => {
+    axios.get.mockImplementation((url) => {
+        return Promise.resolve({"data": {"features": [{"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596326400000,
+          "NewCase": 96,
+          "CumCase": 1845,
+          "NewDeath": 5,
+          "CumDeath": 18
+        }}]}});
+      });
+    data = await retrieveCountryData("ZAF");
+    expect(data.cum_cases).toBe(1845)
+  });
+
+  it("should use yesterdays cached stats if new case numbers is empty", async () => {
+    const date = new Date(new Date() - (90000000));
+    const stats = await Statistics.create({
+      country_code: "ZAF",
+      updated: date,
+      new_cases: 96,
+      cum_cases: 1845,
+      new_deaths: 5,
+      cum_deaths: 18,
+      createdAt: date,
+      updatedAt: date
+    });
+    axios.get.mockImplementation((url) => {
+        return Promise.resolve({"data": {"features": [{"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596326400000,
+          "NewCase": 0,
+          "CumCase": 8888,
+          "NewDeath": 0,
+          "CumDeath": 4444
+        }}]}});
+      });
+    data = await retrieveCountryData("ZAF");
+    expect(data.cum_cases).toBe(1845)
+  });
+
+  it("should use yesterdays stats from arcGIS if cache and new case numbers empty", async () => {
+    axios.get.mockImplementation((url) => {
+        return Promise.resolve({"data": {"features": [{"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596326400000,
+          "NewCase": 0,
+          "CumCase": 8888,
+          "NewDeath": 0,
+          "CumDeath": 4444
+        }}, {"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596240000000,
+          "NewCase": 96,
+          "CumCase": 1845,
+          "NewDeath": 5,
+          "CumDeath": 4444
+        }}]}});
+      });
+    data = await retrieveCountryData("ZAF");
+    expect(data.cum_cases).toBe(1845)
   });
 });
 

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -107,19 +107,17 @@ const featureServerUrl =
 
 function retrieveCountryStatsFromArcGis(countryCode) {
   debug("retrieving from ArcGIS");
-  return axios({
-    method: "get",
-    url: `${featureServerUrl}/${query(countryCode)}`
-  }).then(res => res.data);
+  return axios.get(
+    `${featureServerUrl}/${query(countryCode)}`
+  ).then(res => res.data);
 }
 
 function retrieveGlobalStatsFromArcGis() {
   const usFormatDate = new Intl.DateTimeFormat("en-US").format(new Date());
   debug("retrieving from ArcGIS");
-  return axios({
-    method: "get",
-    url: `${featureServerUrl}/${globalStats(usFormatDate)}`
-  }).then(res => res.data);
+  return axios.get(
+    `${featureServerUrl}/${globalStats(usFormatDate)}`
+  ).then(res => res.data);
 }
 
 function retrieveContactLanguage(client, msisdn) {
@@ -145,6 +143,7 @@ module.exports = {
   retrieveCountryData: retrieveCountryData,
   retrieveGlobalData: retrieveGlobalData,
   retrieveCountryStatsFromArcGis: retrieveCountryStatsFromArcGis,
+  retrieveGlobalStatsFromArcGis: retrieveGlobalStatsFromArcGis,
   shouldNotHaveToUpdate: shouldNotHaveToUpdate,
   retrieveContactLanguage: retrieveContactLanguage,
   retrieveLatestNews: retrieveLatestNews

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -13,6 +13,13 @@ function shouldNotHaveToUpdate(dataObj) {
   return diffMoreThanHour;
 }
 
+function lessThanADayOld(dataObj) {
+  const dayInMs = 24 * 60 * 60 * 1000;
+  const diffLessThanADay = new Date() - new Date(dataObj.updatedAt) < dayInMs;
+  debug(`Difference is less than a day: ${diffLessThanADay}`);
+  return diffLessThanADay;
+}
+
 function retrieveCountryData(countryCode) {
   return Statistics.findOne({
     where: {
@@ -31,6 +38,26 @@ function retrieveCountryData(countryCode) {
           (a, b) => a.attributes.date_epicrv - b.attributes.date_epicrv
         );
         const latest = features.pop().attributes;
+        let yesterday = features.pop();
+        if (yesterday) {
+          yesterday = yesterday.attributes;
+        }
+        // If WHO probably hasn't updated their numbers for the day return 
+        // our cached value or yesterday's value
+        if (latest.NewCase==0 && latest.NewDeath==0 && yesterday && yesterday.NewCase!=0) {
+          if (obj && lessThanADayOld(obj.updated)) {
+            return obj;
+          }
+          return Statistics.create({
+            country_code: countryCode,
+            country_code_2: yesterday.ISO_2_CODE,
+            updated: yesterday.date_epicrv,
+            new_cases: yesterday.NewCase,
+            cum_cases: yesterday.CumCase,
+            new_deaths: yesterday.NewDeath,
+            cum_deaths: yesterday.CumDeath
+          });
+        }
         return Statistics.create({
           country_code: countryCode,
           country_code_2: latest.ISO_2_CODE,
@@ -145,6 +172,7 @@ module.exports = {
   retrieveCountryStatsFromArcGis: retrieveCountryStatsFromArcGis,
   retrieveGlobalStatsFromArcGis: retrieveGlobalStatsFromArcGis,
   shouldNotHaveToUpdate: shouldNotHaveToUpdate,
+  lessThanADayOld: lessThanADayOld,
   retrieveContactLanguage: retrieveContactLanguage,
   retrieveLatestNews: retrieveLatestNews
 };


### PR DESCRIPTION
WHO adds a daily entry to the api at 2am SAST but it only populates the country stats for that entry sometime during the day. This will check if the latest entry has 0 new cases and 0 new deaths. Then, if the previous day's entry does not have 0 for new cases we will load our cached stats or use yesterday's stats instead.