### PR TITLE
Ensure news character count isn't too long

### DIFF
--- a/__tests__/format-message.test.js
+++ b/__tests__/format-message.test.js
@@ -306,8 +306,22 @@ https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-report
     };
     formatted_msg = formatNewsMessage(news_data, "23432434234")
 
-    expect(formatted_msg).toContain("dummy text ever sinc");
-    expect(formatted_msg).not.toContain("dummy text ever since");
+    expect(formatted_msg).toContain("it to make a type specimen");
+    expect(formatted_msg).not.toContain("book It has survived not");
+  });
+  it("should truncate the snippet if it has a fullstop after the 300 character mark", () => {
+    const news_data = {
+      "items": [{
+        "title": "article 1",
+        "link": "some_link",
+        "contentSnippet": "Lorem Ipsum is simply dummy text used by the printing and typesetting industry COVID Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially. unchanged",
+        "pubDate": "Tue, 09 Jun 2020 14:53:34 Z"
+      }]
+    };
+    formatted_msg = formatNewsMessage(news_data, "23432434234")
+
+    expect(formatted_msg).toContain("it to make a type specimen");
+    expect(formatted_msg).not.toContain("book It has survived not");
   });
   it("should decode escaped html", () => {
     const news_data = {

--- a/format-message.js
+++ b/format-message.js
@@ -293,6 +293,9 @@ function formatNewsMessage(newsList, whoNumber) {
       if (end_index < 0) {
         end_index = 150;
       }
+      if (end_index > 300) {
+        end_index = description.indexOf(" ", 250);
+      }
       description = description.substring(0, end_index+1);
     }
     date = item.pubDate.substring(5).replace("Z", "UTC")

--- a/format-message.js
+++ b/format-message.js
@@ -290,10 +290,7 @@ function formatNewsMessage(newsList, whoNumber) {
 
     if (description.length > 300) {
       end_index = description.indexOf(".", 100);
-      if (end_index < 0) {
-        end_index = 150;
-      }
-      if (end_index > 300) {
+      if (end_index < 0 || end_index > 300) {
         end_index = description.indexOf(" ", 250);
       }
       description = description.substring(0, end_index+1);


### PR DESCRIPTION
Currently if the description is >300 characters but the first fullstop is after the 300th character mark we still use the full sentence (This was as long as 800+ characters in one case) 