### PR TITLE
Change arcgis endpoint

### DIFF
--- a/format-message.js
+++ b/format-message.js
@@ -15,8 +15,8 @@ function formatMessage(countryData, globalData, languageCode) {
     item => countryData.country_code === item.alpha3
   ).country_name;
 
-  // The translations were writting for CET so we use that
-  const date = new Date((new Date().getTime())+1 * 60 * 60 * 1000) ;
+  // The translations were writting for CET (UTC+1) so we use that
+  const date = new Date(countryData.updated + 1 * 60 * 60 * 1000) ;
 
   switch (languageCode) {
     case "ITA":

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -130,7 +130,7 @@ const query = country =>
   `query?where=ISO_3_CODE+%3D+'${country}'&returnGeometry=false&outFields=NewCase,CumCase,NewDeath,CumDeath,date_epicrv,ISO_2_CODE&f=json`;
 
 const featureServerUrl =
-  "https://services.arcgis.com/5T5nSi527N4F7luB/arcgis/rest/services/COVID19_hist_cases_adm0_v5_view/FeatureServer/0";
+  "https://services.arcgis.com/5T5nSi527N4F7luB/arcgis/rest/services/COVID_19_Historic_cases_by_country_pt_v7_view/FeatureServer/0";
 
 function retrieveCountryStatsFromArcGis(countryCode) {
   debug("retrieving from ArcGIS");


### PR DESCRIPTION
Change ArcGIS endpoint being used for covid stats.
Also use the date from the country data rather than the current time so that it's slightly more accurate and not misleading