### PR TITLE
Use cached global stats when arcgis has incomplete data

### DIFF
--- a/__tests__/retrieve-data.test.js
+++ b/__tests__/retrieve-data.test.js
@@ -146,6 +146,39 @@ describe("fetch data from arcGIS APIs", () => {
     expect(data.cum_cases).toBe(2222)
   });
 
+  it("should use yesterdays stats from arcGIS if cache is old and new case numbers empty", async () => {
+    const date = new Date(new Date() - (90000000));
+    const stats = await Statistics.create({
+      country_code: "ZAF",
+      updated: date,
+      new_cases: 96,
+      cum_cases: 3333,
+      new_deaths: 5,
+      cum_deaths: 18,
+      createdAt: date,
+      updatedAt: date
+    }, {silent:true});
+    axios.get.mockImplementation((url) => {
+        return Promise.resolve({"data": {"features": [{"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596326400000,
+          "NewCase": 0,
+          "CumCase": 8888,
+          "NewDeath": 0,
+          "CumDeath": 23
+        }}, {"attributes": {
+          "ISO_2_CODE": "ZA",
+          "date_epicrv": 1596240000000,
+          "NewCase": 96,
+          "CumCase": 4444,
+          "NewDeath": 5,
+          "CumDeath": 23
+        }}]}});
+      });
+    data = await retrieveCountryData("ZAF");
+    expect(data.cum_cases).toBe(4444)
+  });
+
   it("should use yesterdays stats from arcGIS if cache and new case numbers empty", async () => {
     axios.get.mockImplementation((url) => {
         return Promise.resolve({"data": {"features": [{"attributes": {

--- a/__tests__/retrieve-data.test.js
+++ b/__tests__/retrieve-data.test.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const {
   retrieveCountryData,
+  retrieveGlobalData,
   retrieveCountryStatsFromArcGis,
   retrieveGlobalStatsFromArcGis,
   shouldNotHaveToUpdate,
@@ -199,6 +200,30 @@ describe("fetch data from arcGIS APIs", () => {
       });
     data = await retrieveCountryData("ZAF");
     expect(data.cum_cases).toBe(5555)
+  });
+
+  it("should use data from the database if global cum_cases has gone down", async () => {
+    const date = new Date(new Date() - (90000000));
+    const stats = await Statistics.create({
+      country_code: "Global",
+      updated: date,
+      new_cases: 96,
+      cum_cases: 7777,
+      new_deaths: 5,
+      cum_deaths: 18,
+      createdAt: date,
+      updatedAt: date
+    }, {silent:true});
+    axios.get.mockImplementation((url) => {
+        return Promise.resolve({"data": {"features": [{"attributes": {
+          "NewCase": 96,
+          "CumCase": 2222,
+          "NewDeath": 5,
+          "CumDeath": 4444
+        }}]}});
+      });
+    data = await retrieveGlobalData();
+    expect(data.cum_cases).toBe(7777)
   });
 });
 

--- a/__tests__/retrieve-data.test.js
+++ b/__tests__/retrieve-data.test.js
@@ -15,6 +15,10 @@ const mockAxios = jest.genMockFromModule('axios')
 mockAxios.create = jest.fn(() => mockAxios)
 
 describe("fetch data from arcGIS APIs", () => {
+  beforeEach(async () => {
+    await Statistics.destroy({truncate: true});
+  });
+
   it("should add the country to the country query", async () => {
     axios.get.mockImplementation((url) => {
       if (url.indexOf("NLD") >= 0 ) {
@@ -84,7 +88,7 @@ describe("fetch data from arcGIS APIs", () => {
     expect(lessThanADayOld(oldMock)).toBe(false);
   });
 
-  it("should get cached data from the database", async () => {
+  it("should get cached data from the database if less than an hour old", async () => {
     const date = new Date();
     const stats = await Statistics.create({
       country_code: "ZAF",
@@ -107,27 +111,27 @@ describe("fetch data from arcGIS APIs", () => {
           "ISO_2_CODE": "ZA",
           "date_epicrv": 1596326400000,
           "NewCase": 96,
-          "CumCase": 1845,
+          "CumCase": 1111,
           "NewDeath": 5,
           "CumDeath": 18
         }}]}});
       });
     data = await retrieveCountryData("ZAF");
-    expect(data.cum_cases).toBe(1845)
+    expect(data.cum_cases).toBe(1111)
   });
 
   it("should use yesterdays cached stats if new case numbers is empty", async () => {
-    const date = new Date(new Date() - (90000000));
+    const date = new Date(new Date() - (70000000));
     const stats = await Statistics.create({
       country_code: "ZAF",
       updated: date,
       new_cases: 96,
-      cum_cases: 1845,
+      cum_cases: 2222,
       new_deaths: 5,
       cum_deaths: 18,
       createdAt: date,
       updatedAt: date
-    });
+    }, {silent:true});
     axios.get.mockImplementation((url) => {
         return Promise.resolve({"data": {"features": [{"attributes": {
           "ISO_2_CODE": "ZA",
@@ -139,7 +143,7 @@ describe("fetch data from arcGIS APIs", () => {
         }}]}});
       });
     data = await retrieveCountryData("ZAF");
-    expect(data.cum_cases).toBe(1845)
+    expect(data.cum_cases).toBe(2222)
   });
 
   it("should use yesterdays stats from arcGIS if cache and new case numbers empty", async () => {
@@ -155,13 +159,13 @@ describe("fetch data from arcGIS APIs", () => {
           "ISO_2_CODE": "ZA",
           "date_epicrv": 1596240000000,
           "NewCase": 96,
-          "CumCase": 1845,
+          "CumCase": 5555,
           "NewDeath": 5,
           "CumDeath": 4444
         }}]}});
       });
     data = await retrieveCountryData("ZAF");
-    expect(data.cum_cases).toBe(1845)
+    expect(data.cum_cases).toBe(5555)
   });
 });
 

--- a/__tests__/send-message.test.js
+++ b/__tests__/send-message.test.js
@@ -46,16 +46,6 @@ const mockResponse = () => {
 
 // Create a stats object that will be pulled from the db
 const date = new Date();
-const stats = Statistics.create({
-  country_code: "ZAF",
-  updated: date,
-  new_cases: 96,
-  cum_cases: 1845,
-  new_deaths: 5,
-  cum_deaths: 18,
-  createdAt: date,
-  updatedAt: date
-});
 
 describe("send homepage messages", () => {
   it("should fail for an unknown country", async () => {
@@ -69,6 +59,17 @@ describe("send homepage messages", () => {
   });
 
   it("should send data to queue for known countries", async () => {
+    const stats = Statistics.create({
+      country_code: "ZAF",
+      updated: date,
+      new_cases: 96,
+      cum_cases: 1845,
+      new_deaths: 5,
+      cum_deaths: 18,
+      createdAt: date,
+      updatedAt: date
+    });
+
     let req = mockRequest();
     req.body.contacts[0].wa_id="27615551234";
     const res = mockResponse();

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -97,7 +97,9 @@ function retrieveGlobalData() {
           (a, b) => a.attributes.date_epicrv - b.attributes.date_epicrv
         );
         const latest = features.pop().attributes;
-        if (latest.CumCase === null && obj){
+        // Sometimes the endpoint gives us some strange data so if the cumulative cases
+        // is empty or has gone down then use the cached value
+        if (obj && (latest.CumCase === null || latest.CumCase < obj.cum_cases)){
           return obj;
         }
         return Statistics.create({

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -44,19 +44,21 @@ function retrieveCountryData(countryCode) {
         }
         // If WHO probably hasn't updated their numbers for the day return 
         // our cached value or yesterday's value
-        if (latest.NewCase==0 && latest.NewDeath==0 && yesterday && yesterday.NewCase!=0) {
-          if (obj && lessThanADayOld(obj.updated)) {
+        if (latest.NewCase==0 && latest.NewDeath==0)  {
+          if (obj && lessThanADayOld(obj)) {
             return obj;
           }
-          return Statistics.create({
-            country_code: countryCode,
-            country_code_2: yesterday.ISO_2_CODE,
-            updated: yesterday.date_epicrv,
-            new_cases: yesterday.NewCase,
-            cum_cases: yesterday.CumCase,
-            new_deaths: yesterday.NewDeath,
-            cum_deaths: yesterday.CumDeath
-          });
+          if (yesterday && yesterday.NewCase!=0) {
+            return Statistics.create({
+              country_code: countryCode,
+              country_code_2: yesterday.ISO_2_CODE,
+              updated: yesterday.date_epicrv,
+              new_cases: yesterday.NewCase,
+              cum_cases: yesterday.CumCase,
+              new_deaths: yesterday.NewDeath,
+              cum_deaths: yesterday.CumDeath
+            });
+          }
         }
         return Statistics.create({
           country_code: countryCode,


### PR DESCRIPTION
Sometimes the Global numbers returned from the arcgis endpoint have lower cumulative numbers than the previous day. We don't want to report or store these numbers.
We also want to prioritise using our cached data for country stats when we're still waiting for WHO to update their stats for the day. Rather than using their report for yesterday.

There were some minor fixes to tests as well. Existing Statistics objects from other tests were masking test failures.