### PR TITLE
Set turn client timeout to 1000ms and catch error

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,7 +25,7 @@ function sendBackgroundedMsgsWithDelay(data){
   const token = TOKENS[number];
   const client = axios.create({
     baseURL: TURN_URL,
-    timeout: 300,
+    timeout: 1000,
     headers: { Authorization: `Bearer ${token}` }
   });
   return sendWithDelay(client, msgId, msgs, user, delay);

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -160,7 +160,10 @@ function retrieveContactLanguage(client, msisdn) {
         headers: {
           "Accept": "application/vnd.v1+json"
         },
-      }).then(res => res.data.fields.language);
+      }).then(res => res.data.fields.language)
+      .catch(err => {
+        console.error(err.message);
+      });
 }
 
 const rssFeedUrl = "https://www.who.int/rss-feeds/news-english.xml";

--- a/send-message.js
+++ b/send-message.js
@@ -49,7 +49,7 @@ async function sendCountryDataBasedOnPhoneNumber(req, res) {
   const token = TOKENS[who_number];
   const client = axios.create({
     baseURL: TURN_URL,
-    timeout: 300,
+    timeout: 1000,
     headers: { Authorization: `Bearer ${token}` }
   });
 
@@ -86,7 +86,7 @@ async function sendLatestNews(req, res) {
   const token = TOKENS[who_number];
   const client = axios.create({
     baseURL: TURN_URL,
-    timeout: 300,
+    timeout: 1000,
     headers: { Authorization: `Bearer ${token}` }
   });
 


### PR DESCRIPTION
the new Axios version seems to be a lot stricter about timeouts.
the Turn calls consistently timeout at 300ms, about 50% of the time at 600ms. 1000ms timeout gives them enough time.
This doesn't seem to affect the response time of the webhook, which bounces between 800ms and 1700ms on my local machine.