### PR TITLE
Fix stale news

### DIFF
--- a/__tests__/retrieve-data.test.js
+++ b/__tests__/retrieve-data.test.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const https = require("https");
 const {
   retrieveCountryData,
   retrieveGlobalData,
@@ -6,7 +7,8 @@ const {
   retrieveGlobalStatsFromArcGis,
   shouldNotHaveToUpdate,
   lessThanADayOld,
-  retrieveContactLanguage
+  retrieveContactLanguage,
+  retrieveLatestNews
 } = require("../retrieve-data");
 const { Statistics } = require("../models");
 
@@ -49,6 +51,23 @@ describe("fetch data from arcGIS APIs", () => {
 
     expect(data.message).toBe("Date present in url");
     spy.mockRestore()
+  });
+
+  it("should add the date to the news query", async () => {
+    // Mocks
+    const mock_date = new Date('May 20, 2020 11:20:18');
+    const spy = jest
+      .spyOn(global, 'Date')
+      .mockImplementationOnce(() => mock_date);
+
+    const spy2 = jest
+      .spyOn(https, 'get');
+
+    await retrieveLatestNews();
+
+    expect(spy2.mock.calls[0][0].href).toBe('https://www.who.int/rss-feeds/news-english.xml?req_time=5/20/2020');
+    spy.mockRestore();
+    spy2.mockRestore();
   });
 
   it("should not have to update if less than 1 hour old", () => {

--- a/retrieve-data.js
+++ b/retrieve-data.js
@@ -166,12 +166,14 @@ function retrieveContactLanguage(client, msisdn) {
       });
 }
 
-const rssFeedUrl = "https://www.who.int/rss-feeds/news-english.xml";
+// Add the date to the rss url so that it isn't cached
+const rssFeedUrl = date =>
+  `https://www.who.int/rss-feeds/news-english.xml?req_time=${date}`;
 
 async function retrieveLatestNews() {
+  const usFormatDate = new Intl.DateTimeFormat("en-US").format(new Date());
   debug("retrieving from RSS");
-  axios.get(rssFeedUrl).then(res => console.log(res.data));
-  return feed = await parser.parseURL(rssFeedUrl)
+  return feed = await parser.parseURL(rssFeedUrl(usFormatDate))
 }
 
 module.exports = {

--- a/send-message.js
+++ b/send-message.js
@@ -95,7 +95,6 @@ async function sendLatestNews(req, res) {
   debug(`/news called for ${user} with message id ${messageId}`);
 
   const newsList = await retrieveLatestNews();
-  console.log(newsList); // Temp debug statement!!
   const msg = formatNewsMessage(newsList, who_number);
   inspect("news message:")(msg);
   return sendMessage(client, messageId, msg, user)


### PR DESCRIPTION
The News RSS feed has some sort of caching issue and the data we're getting from it is very stale.
I added a query string with the date so that each day we'll get the latest news and then that will be cached for the day.