### PR TITLE
Turn outbound status notification update

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -90,3 +90,25 @@ describe("/stats endpoint", () => {
       .expect(200, done);
   });
 });
+
+describe("/news endpoint", () => {
+  it("should successfully receive read status", (done) => {
+    const testMsg = {
+      "statuses": [
+        {
+          "id": "ABGGFlA5FpafAgo6tHcNmNjXmuSf",
+          "status": "read",
+          "timestamp": "1518694700",
+          "message": {
+            "recipient_id":"16315555555"
+          }
+        }
+      ]
+    };
+    request(app)
+      .post("/news")
+      .send(testMsg)
+      .set("Accept", "application/json")
+      .expect(200, done);
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -51,4 +51,42 @@ describe("/stats endpoint", () => {
       .expect(200, done)
       .expect({ country: "unknown" });
   });
+  it("should successfully receive sent status", (done) => {
+    const testMsg = {
+      "statuses": [
+        {
+          "id": "ABGGFlA5FpafAgo6tHcNmNjXmuSf",
+          "status": "sent",
+          "timestamp": "1518694700",
+          "message": {
+            "recipient_id":"16315555555"
+          }
+        }
+      ]
+    };
+    request(app)
+      .post("/stats")
+      .send(testMsg)
+      .set("Accept", "application/json")
+      .expect(200, done);
+  });
+  it("should successfully receive read status", (done) => {
+    const testMsg = {
+      "statuses": [
+        {
+          "id": "ABGGFlA5FpafAgo6tHcNmNjXmuSf",
+          "status": "read",
+          "timestamp": "1518694700",
+          "message": {
+            "recipient_id":"16315555555"
+          }
+        }
+      ]
+    };
+    request(app)
+      .post("/stats")
+      .send(testMsg)
+      .set("Accept", "application/json")
+      .expect(200, done);
+  });
 });

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ if (process.env.SENTRY_DSN) {
 
 app.post("/stats", async (req, res) => {
   if (req.body.statuses) {
-    const { recipient_id, status } = req.body.statuses[0];
+    const { message:{ recipient_id }, status } = req.body.statuses[0];
     inspect("status message: ")(
       `recipient_id: ${recipient_id}, status: ${status}`
     );
@@ -34,7 +34,7 @@ app.post("/stats", async (req, res) => {
 
 app.post("/news", async (req, res) => {
   if (req.body.statuses) {
-    const { recipient_id, status } = req.body.statuses[0];
+    const { message:{ recipient_id }, status } = req.body.statuses[0];
     inspect("status message: ")(
       `recipient_id: ${recipient_id}, status: ${status}`
     );
@@ -50,7 +50,7 @@ app.post("/news", async (req, res) => {
 
 app.post("/homepage", async (req, res) => {
   if (req.body.statuses) {
-    const { recipient_id, status } = req.body.statuses[0];
+    const { message:{ recipient_id }, status } = req.body.statuses[0];
     inspect("status message: ")(
       `recipient_id: ${recipient_id}, status: ${status}`
     );


### PR DESCRIPTION
Turn outbound status notification payload has changed to this

{
  "statuses": [
    {
      "id": "ABGGFlA5FpafAgo6tHcNmNjXmuSf",
      "status": "sent",
      "timestamp": "1518694700",
      "message": {
        "recipient_id":"16315555555"
      }
    }
  ]
}

with recipient_id now under message key. It used to be on the same level as id.